### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+zatacka (0.1.8-6) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 18:01:23 +0100
+
 zatacka (0.1.8-5) unstable; urgency=medium
 
   [ Alexandre Dantas ]

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9), autotools-dev, dh-autoreconf, autoconf,
                ttf-dejavu
 Standards-Version: 3.9.5
 Homepage: http://zatacka.sourceforge.net/
-Vcs-Git: git://github.com/alexdantas/zatacka.debian.git -b master
+Vcs-Git: https://github.com/alexdantas/zatacka.debian.git -b master
 Vcs-Browser: https://github.com/alexdantas/zatacka.debian
 
 Package: zatacka


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
