### PR TITLE
Update dependency on the transitional dummy ttf-dejavu-core

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+zatacka (0.1.8-6) UNRELEASED; urgency=medium
+
+  * Update dependency on the transitional dummy ttf-dejavu-core (which was
+    dropped from unstable) to fonts-dejavu-core (Closes: #961863)
+    - debian/control
+    - debian/zatacka.links
+
+ -- Olivier Tilloy <olivier.tilloy@canonical.com>  Thu, 04 Jun 2020 15:21:39 +0200
+
 zatacka (0.1.8-5) unstable; urgency=medium
 
   [ Alexandre Dantas ]

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Alexandre Dantas <eu@alexdantas.net>
 Build-Depends: debhelper (>= 9), autotools-dev, dh-autoreconf, autoconf,
                libsdl1.2-dev, libsdl-ttf2.0-dev, libsdl-image1.2-dev,
-               ttf-dejavu
+               fonts-dejavu
 Standards-Version: 3.9.5
 Homepage: http://zatacka.sourceforge.net/
 Vcs-Git: git://github.com/alexdantas/zatacka.debian.git -b master

--- a/debian/zatacka.links
+++ b/debian/zatacka.links
@@ -1,1 +1,1 @@
-usr/share/fonts/truetype/ttf-dejavu/DejaVuSans.ttf usr/share/games/zatacka/font.ttf
+usr/share/fonts/truetype/dejavu/DejaVuSans.ttf usr/share/games/zatacka/font.ttf


### PR DESCRIPTION
(which was dropped from unstable) to fonts-dejavu-core (Closes: #961863)